### PR TITLE
changed http call to IFTTT to use POST instead of GET

### DIFF
--- a/src/IFTTTWebhook.cpp
+++ b/src/IFTTTWebhook.cpp
@@ -37,107 +37,82 @@ int IFTTTWebhook::trigger(const char* value1, const char* value2) {
   return IFTTTWebhook::trigger(value1, value2, NULL);
 }
 
-#ifdef ESP32
-const char* _ifttt_root_certificate = \
-"-----BEGIN CERTIFICATE-----\n" \
-"MIIE0DCCA7igAwIBAgIBBzANBgkqhkiG9w0BAQsFADCBgzELMAkGA1UEBhMCVVMx" \
-"EDAOBgNVBAgTB0FyaXpvbmExEzARBgNVBAcTClNjb3R0c2RhbGUxGjAYBgNVBAoT" \
-"EUdvRGFkZHkuY29tLCBJbmMuMTEwLwYDVQQDEyhHbyBEYWRkeSBSb290IENlcnRp" \
-"ZmljYXRlIEF1dGhvcml0eSAtIEcyMB4XDTExMDUwMzA3MDAwMFoXDTMxMDUwMzA3" \
-"MDAwMFowgbQxCzAJBgNVBAYTAlVTMRAwDgYDVQQIEwdBcml6b25hMRMwEQYDVQQH" \
-"EwpTY290dHNkYWxlMRowGAYDVQQKExFHb0RhZGR5LmNvbSwgSW5jLjEtMCsGA1UE" \
-"CxMkaHR0cDovL2NlcnRzLmdvZGFkZHkuY29tL3JlcG9zaXRvcnkvMTMwMQYDVQQD" \
-"EypHbyBEYWRkeSBTZWN1cmUgQ2VydGlmaWNhdGUgQXV0aG9yaXR5IC0gRzIwggEi" \
-"MA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC54MsQ1K92vdSTYuswZLiBCGzD" \
-"BNliF44v/z5lz4/OYuY8UhzaFkVLVat4a2ODYpDOD2lsmcgaFItMzEUz6ojcnqOv" \
-"K/6AYZ15V8TPLvQ/MDxdR/yaFrzDN5ZBUY4RS1T4KL7QjL7wMDge87Am+GZHY23e" \
-"cSZHjzhHU9FGHbTj3ADqRay9vHHZqm8A29vNMDp5T19MR/gd71vCxJ1gO7GyQ5HY" \
-"pDNO6rPWJ0+tJYqlxvTV0KaudAVkV4i1RFXULSo6Pvi4vekyCgKUZMQWOlDxSq7n" \
-"eTOvDCAHf+jfBDnCaQJsY1L6d8EbyHSHyLmTGFBUNUtpTrw700kuH9zB0lL7AgMB" \
-"AAGjggEaMIIBFjAPBgNVHRMBAf8EBTADAQH/MA4GA1UdDwEB/wQEAwIBBjAdBgNV" \
-"HQ4EFgQUQMK9J47MNIMwojPX+2yz8LQsgM4wHwYDVR0jBBgwFoAUOpqFBxBnKLbv" \
-"9r0FQW4gwZTaD94wNAYIKwYBBQUHAQEEKDAmMCQGCCsGAQUFBzABhhhodHRwOi8v" \
-"b2NzcC5nb2RhZGR5LmNvbS8wNQYDVR0fBC4wLDAqoCigJoYkaHR0cDovL2NybC5n" \
-"b2RhZGR5LmNvbS9nZHJvb3QtZzIuY3JsMEYGA1UdIAQ/MD0wOwYEVR0gADAzMDEG" \
-"CCsGAQUFBwIBFiVodHRwczovL2NlcnRzLmdvZGFkZHkuY29tL3JlcG9zaXRvcnkv" \
-"MA0GCSqGSIb3DQEBCwUAA4IBAQAIfmyTEMg4uJapkEv/oV9PBO9sPpyIBslQj6Zz" \
-"91cxG7685C/b+LrTW+C05+Z5Yg4MotdqY3MxtfWoSKQ7CC2iXZDXtHwlTxFWMMS2" \
-"RJ17LJ3lXubvDGGqv+QqG+6EnriDfcFDzkSnE3ANkR/0yBOtg2DZ2HKocyQetawi" \
-"DsoXiWJYRBuriSUBAA/NxBti21G00w9RKpv0vHP8ds42pM3Z2Czqrpv1KrKQ0U11" \
-"GIo/ikGQI31bS/6kA1ibRrLDYGCD+H1QQc7CoZDDu+8CL9IVVO5EFdkKrqeKM+2x" \
-"LXY2JtwE65/3YR8V3Idv7kaWKK2hJn0KCacuBKONvPi8BDAB" \
-"-----END CERTIFICATE-----\n";
-#endif
-
 int IFTTTWebhook::trigger(const char* value1, const char* value2, const char* value3) {
   HTTPClient http;
   const char* ifttt_base = "https://maker.ifttt.com/trigger";
 
-  int url_length = strlen(ifttt_base) + strlen("/") + strlen(_event_name) + strlen("/with/key/") + strlen(_api_key) + strlen("?") + (strlen("&valuex=")*3);
-  url_length += (value1 ? strlen(value1) : 0) + (value2 ? strlen(value2) : 0) + (value3 ? strlen(value3) : 0);
-  url_length += 5;
+  // Compute URL length
+  int url_length = 1 + strlen(ifttt_base) + strlen("/") + strlen(_event_name) + strlen("/with/key/") + strlen(_api_key);
   char ifttt_url[url_length];
+
+  // Compute Payload length
+  int payload_length = 37 + (value1 ? strlen(value1) : 0) + (value2 ? strlen(value2) : 0) + (value3 ? strlen(value3) : 0);
+  char ifttt_payload[payload_length];
 
 #ifdef IFTTT_WEBHOOK_DEBUG  
   Serial.print("URL length: ");
   Serial.println(url_length);
+  Serial.print("Payload length: ");
+  Serial.println(payload_length);
 #endif
-  
+
+  // Compute URL
   snprintf(ifttt_url, url_length, "%s/%s/with/key/%s", ifttt_base, _event_name, _api_key);
-  if(value1 || value2 || value3) {
-    strcat(ifttt_url, "?");
-  }
+
+  // Compute Payload (JSON), e.g. {value1:"A",value2:"B",value3:"C"}
+  snprintf(ifttt_payload, payload_length, "{");
 
   if(value1) {
-    strcat(ifttt_url, "value1=\"");
-    strcat(ifttt_url, value1);
-    strcat(ifttt_url, "\"");
+    strcat(ifttt_payload, "\"value1\":\"");
+    strcat(ifttt_payload, value1);
+    strcat(ifttt_payload, "\"");
     if(value2 || value3) {
-      strcat(ifttt_url, "&");
+      strcat(ifttt_payload, ",");
     }
-  }
-  
-  if(value2) {
-    strcat(ifttt_url, "value2=\"");
-    strcat(ifttt_url, value2);
-    strcat(ifttt_url, "\"");
-    if(value3) {
-      strcat(ifttt_url, "&");
-    }
-  }
-  
-  if(value3) {
-    strcat(ifttt_url, "value3=\"");
-    strcat(ifttt_url, value3);
-    strcat(ifttt_url, "\"");
   }
 
-#ifdef IFTTT_WEBHOOK_DEBUG  
+  if(value2) {
+    strcat(ifttt_payload, "\"value2\":\"");
+    strcat(ifttt_payload, value2);
+    strcat(ifttt_payload, "\"");
+    if(value3) {
+      strcat(ifttt_payload, ",");
+    }
+  }
+
+  if(value3) {
+    strcat(ifttt_payload, "\"value3\":\"");
+    strcat(ifttt_payload, value3);
+    strcat(ifttt_payload, "\"");
+  }
+
+  strcat(ifttt_payload, "}");
+
+#ifdef IFTTT_WEBHOOK_DEBUG
+  Serial.print("URL: ");
   Serial.println(ifttt_url);
+  Serial.print("Payload: ");
+  Serial.println(ifttt_payload);
 #endif
-  
-#ifdef ESP32
-  // certificate: openssl s_client -showcerts -connect maker.ifttt.com:443 < /dev/null
-  http.begin(ifttt_url, _ifttt_root_certificate);
-#else
+
+  // HTTPS POST with the root certificate method returns 'connection refused' with a ESP2 Dev Module board, using fingerprint in all cases
   // fingerprint: openssl s_client -connect maker.ifttt.com:443  < /dev/null 2>/dev/null | openssl x509 -fingerprint -noout | cut -d'=' -f2
   http.begin(ifttt_url, _ifttt_fingerprint);
-#endif
-  int httpCode = http.GET();
+  http.addHeader("Content-Type", "application/json");
+  int httpCode = http.POST(ifttt_payload);
 
 #ifdef IFTTT_WEBHOOK_DEBUG  
+  Serial.printf("[HTTP] POST... code: %d\n", httpCode);
   if (httpCode > 0) {
-    Serial.printf("[HTTP] GET... code: %d\n", httpCode);
-
     if(httpCode == HTTP_CODE_OK) {
       Serial.println(http.getString());
     }
   } else {
-      Serial.printf("[HTTP] GET... failed, error: %s\n", http.errorToString(httpCode).c_str());
-    }
+      Serial.printf("[HTTP] POST... failed, error %s\n", http.errorToString(httpCode).c_str());
+  }
 #endif
 
-    http.end();
+  http.end();
 
-    return httpCode != HTTP_CODE_OK;
-  }
+  return httpCode != HTTP_CODE_OK;
+}


### PR DESCRIPTION
The GET implementation does not support values with spaces. The workaround would have been to percent-escape the value strings (replace spaces with %20, etc.), which is the approach intimated by the `urlencode ` branch. The HTTPClient library however doesn't includes a method for this, and IFTTTWebhook is not the right place to implement it.

A better approach I believe is to use POST instead of GET, and pass the values as JSON payload. Aside from not having to percent-encode the values, this has the added benefit of dismissing future issues around maximum length for the values, constraints by the size limit of the URL supported by the IFTTT webserver (unknown by me, but certainly limited). POST may also have added security benefits. 

A side-effect of this change is the incompatibility of HTTPS POST using the root cert, so I'm proposing to revert to the fingerprint approach which works fine. (The root cert approach worked fine with GET on my ESP2 Dev Module board, possibly an issue with the WiFi library? I didn't dig deeper, fingerprint works.)

This patch, if accepted, resolves issue #8 and renders redundant the outstanding work on `urlencode` branch.